### PR TITLE
fix: use `fantomas` command default settings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,10 +53,10 @@ export function activate(context: vscode.ExtensionContext) {
     };
     const cfg = vscode.workspace.getConfiguration('fantomas');
     return Object.keys(keys)
-      .filter(k => cfg.get(k, keys[k]) !== false)
+      .filter(k => cfg.get(k, keys[k]) !== keys[k])
       .reduce((arr, k) => {
         const val = cfg.get(k, keys[k]);
-        return val === true ? [...arr, '--' + k] : [...arr, '--' + k, val];
+        return typeof val === 'boolean' ? [...arr, '--' + k] : [...arr, '--' + k, val];
       }, []);
   }
 


### PR DESCRIPTION
First of all, thank you for make this great extension. But there is something problem.

When I don't change any settings for this extension, "Format Document" command expected:

```bash
`./fantomas "fantomas.tmp.fs"
```

But auctually got:

```bash
`./fantomas "fantomas.tmp.fs" --noSpaceBeforeArgument --noSpaceBeforeColon --noSpaceAfterComma --noSpaceAfterSemiColon --noSpaceAroundDelimiter`
```

Related issue: https://github.com/pd29/vscode-fantomas-fmt/issues/7